### PR TITLE
defaultname / defaulitmail をスレタイにマッチできるようにする

### DIFF
--- a/chaika/chrome/content/chaika/post/wizard.js
+++ b/chaika/chrome/content/chaika/post/wizard.js
@@ -783,7 +783,8 @@ var FormPage = {
         }
 
         let boardURL = gBoard.url.spec;
-        let lines = ChaikaCore.io.readString(defaultDataFile, "Shift_JIS")
+        let titleSpec = ((gWizType == WIZ_TYPE_RES) ? gThread.title : gBoard.getTitle());
+        let lines = ChaikaCore.io.readString(defaultDataFile, "UTF-8")
                                  .split(/[\n\r]+/);
 
         for(let i=0; i<lines.length; i++){
@@ -795,13 +796,22 @@ var FormPage = {
 
 
             let [boardID, defaultData, target] = lines[i].split(/\t+/);
+            let title = '';
+
+            let idx = boardID.indexOf(' ');
+            if(idx !== -1){
+                // スペースより後ろをスレタイ
+                title = boardID.slice(idx + 1);
+                // スペースより前を boardID とする
+                boardID = boardID.slice(0, idx);
+            }
 
             if(target && ((target === 'thread' && gWizType !== WIZ_TYPE_NEW_THREAD) ||
                           (target === 'post' && gWizType !== WIZ_TYPE_RES))){
                 continue;
             }
 
-            if(boardURL.contains(boardID)){
+            if(boardURL.contains(boardID) && titleSpec.contains(title)){
                 return defaultData;
             }
         }

--- a/chaika/chrome/content/chaika/post/wizard.js
+++ b/chaika/chrome/content/chaika/post/wizard.js
@@ -784,7 +784,7 @@ var FormPage = {
 
         let boardURL = gBoard.url.spec;
         let titleSpec = ((gWizType == WIZ_TYPE_RES) ? gThread.title : gBoard.getTitle());
-        let lines = ChaikaCore.io.readString(defaultDataFile, "UTF-8")
+        let lines = ChaikaCore.io.readString(defaultDataFile, "Shift_JIS")
                                  .split(/[\n\r]+/);
 
         for(let i=0; i<lines.length; i++){


### PR DESCRIPTION
スレッドごとにコテハンをつけることを可能にするため、 [defaultname / defaulitmail](https://github.com/chaika/chaika/wiki/defaultname.txt-&-defaultmail.txt) を板名やスレタイにマッチできるようにした。

具体的には、 defaultname / defaulitmail の書式を下記のようにする。
```
板URL[半角スペース]板名かスレタイ[1個以上のTAB]設定したい値[1個以上のTAB]threadかpost
```
板URLに半角スペースはないだろうし、 MediaWiki の外部リンクの記法が `[https://github.com/ Github]` のように半角スペース区切りだったので半角スペース区切りを採用。（行の一番後ろはメモとして使用して言るので個人的には付け加えてほしくない…）

空文字列はすべての文字列にマッチするので、どちらかだけでも大丈夫。

例: 板URLのみ（互換性）
```
jbbs.shitaraba.net/computer/44179/[TAB]MyName[TAB]post
```
例: 板URLとスレタイの両方
```
jbbs.shitaraba.net/computer/44179/ 避難所[TAB]MyName[TAB]post
```
例: スレタイのみ（半角スペースは必須）
```
 避難所[TAB]MyName[TAB]post
```
