### PR TITLE
スレッド一覧、ログマネージャのページリロード時に終了処理が呼ばれるのを回避

### DIFF
--- a/chaika/chrome/content/chaika/board/log-manager.js
+++ b/chaika/chrome/content/chaika/board/log-manager.js
@@ -11,16 +11,19 @@ const Ci = Components.interfaces;
 const Cc = Components.classes;
 const Cr = Components.results;
 
+var gLogManagerReloaded = false;
 
 /**
  * 開始時の処理
  */
 function startup(){
+    gLogManagerReloaded = false;
     if(location.protocol === 'chaika:'){
         console.info('This page is loaded in the content process. Reload!');
         location.href = 'chrome://chaika/content/board/log-manager.xul';
         return;
     }
+    gLogManagerReloaded = true;
 
     ThreadUpdateObserver.startup();
     setTimeout(function(){ delayStartup(); }, 0);
@@ -35,6 +38,7 @@ function delayStartup(){
  * 終了時の処理
  */
 function shutdown(){
+    if(!gLogManagerReloaded) return;
     ThreadUpdateObserver.shutdown();
 }
 

--- a/chaika/chrome/content/chaika/board/page.js
+++ b/chaika/chrome/content/chaika/board/page.js
@@ -53,11 +53,13 @@ var gSubjectDownloader;
 var gSettingDownloader;
 var gBoardMoveChecker;
 var gNewURL;
+var gPageReloaded = false;
 
 /**
  * 開始時の処理
  */
 function startup(){
+    gPageReloaded = false;
     if(location.protocol === 'chaika:'){
         console.info('This page is loaded in the content process. Reload!');
 
@@ -70,6 +72,7 @@ function startup(){
         location.href = boardXUL + '?' + params;
         return;
     }
+    gPageReloaded = true;
 
     PrefObserver.start();
 
@@ -138,6 +141,8 @@ function startup(){
  * 終了時の処理
  */
 function shutdown(){
+    if(!gPageReloaded) return;
+
     PrefObserver.stop();
 
     if(!BoardTree.firstInitBoardTree){


### PR DESCRIPTION
https://github.com/chaika/chaika/issues/325 修正。愚直ですがとりあえず。