### PR TITLE
ChaikaCore の deprecation warning をオプション化

### DIFF
--- a/chaika/defaults/preferences/chaika-pref.js
+++ b/chaika/defaults/preferences/chaika-pref.js
@@ -1,4 +1,5 @@
 pref("extensions.chaika.logger.level", 2);
+pref("extensions.chaika.deprecation-warning.enabled", false);
 pref('extensions.chaika.releasenotes_showed', '1.5.7');
 
 // general

--- a/chaika/modules/ChaikaCore.js
+++ b/chaika/modules/ChaikaCore.js
@@ -1304,6 +1304,7 @@ ChaikaHistory.prototype = {
 
 
 const loggerLevel = Services.prefs.getIntPref("extensions.chaika.logger.level");
+const enableWarning = Services.prefs.getBoolPref("extensions.chaika.deprecation-warning.enabled");
 
 this.ChaikaCore = new Proxy(ChaikaCore_, {
 
@@ -1317,7 +1318,7 @@ this.ChaikaCore = new Proxy(ChaikaCore_, {
             // because ChaikaCore is still widely used in the chaika codebase.
             if(loggerLevel > 40 && /:\/\/chaika|chaika@chaika\.xrea\.jp/.test(caller.filename)){
                 // Do not warn
-            }else{
+            }else if(enableWarning){
                 Deprecated.warning('ChaikaCore is deprecated. It will be removed from chaika in the future.',
                                    'https://github.com/chaika/chaika/issues/234');
             }


### PR DESCRIPTION
現状、デバッグしようとログレベルを変更すると大量の警告メッセージでコンソールログが流されてしまいます。
オプションを追加してデフォルト無効にしましょう。
関連: https://github.com/chaika/chaika/issues/286