### PR TITLE
includes.bbs および excludes.bbs ルール修正

### DIFF
--- a/chaika/modules/utils/URLUtils.js
+++ b/chaika/modules/utils/URLUtils.js
@@ -23,15 +23,16 @@ let includes = {
         /^https?:\/\/\w+\.bbspink.com\//,
         /^https?:\/\/\w+\.machi\.to\//,
         /^https?:\/\/jbbs\.shitaraba\.net\//,
+        /^https?:\/\/jbbs\.livedoor\.net\//,
         /^https?:\/\/\w+\.2ch\.sc\//,
         /^https?:\/\/blogban\.net\//,
         /^https?:\/\/ex14\.vip2ch\.com\//,
         /^https?:\/\/\w+\.open2ch\.net\//,
-        /^https?:\/\/\w+\.jikkyo.org\//,
-        /^https?:\/\/\w+\.next2ch.net\//,
+        /^https?:\/\/\w+\.jikkyo\.org\//,
+        /^https?:\/\/next2ch\.net\//,
+        /^https?:\/\/bbs\.nicovideo\.jp\//,
         /^https?:\/\/\w+\.plusvip\.jp\//,
         /^https?:\/\/\w+\.blogbbs\.net\//,
-        /^https?:\/\/bbs\.shingetsu\.info\//,
         /^https?:\/\/\w+\.m-ch\.jp\//,
         /^https?:\/\/uravip.tonkotsu\.jp\//,
         /^https?:\/\/7gon\.jp\//,
@@ -54,7 +55,6 @@ let excludes = {
         /bbsmenu\.html?/i,                  // BBSMENU of most 2ch-compatible BBS.
         /\/cbm\//,                          // CBM Custom BBS Menu provided by jikkyo.org.
         /\.txt$/,
-        /shingetsu\.info\/gateway\.cgi/,
 
         /* Shitaraba */
         /\/subject\.cgi\//,
@@ -79,7 +79,7 @@ let excludes = {
         /c\.2ch\.net/,             // Mobile-version 2ch.net
         /p2\.2ch\.net/,            // Ads of Ronin
         /conbini\.2ch\.net/,       // Ads of Ronin
-        /\/test\/bbs\.cgi/,        // CGI for posting
+        /\.cgi/,                   // CGI
 
         /* bbspink.com */
         /headline\.bbspink\.net/,  // Headline on bbspink.com


### PR DESCRIPTION
includes.bbs はjikkyo.org と next2ch.net を修正、したらばの旧ドメインとニコニコ動画掲示板を追加。そして新月はchaikaで動作しなかったので削除しました。excludes.bbs は http://qb7.2ch.net/_403/madakana.cgi などありますので .cgi のみで除外としました。