### PR TITLE
scratchpad のモジュール位置変更対応

### DIFF
--- a/chaika/chrome/content/chaika/bbsmenu/page.js
+++ b/chaika/chrome/content/chaika/bbsmenu/page.js
@@ -173,7 +173,12 @@
             favBoardFile.appendRelativePath('favorite_boards.xml');
 
             if(ChaikaCore.pref.getBool('bbsmenu.open_favs_in_scratchpad')){
-                let { ScratchpadManager } = Cu.import('resource:///modules/devtools/scratchpad-manager.jsm', {});
+                try{
+                    var { ScratchpadManager } = Cu.import('resource:///modules/devtools/scratchpad-manager.jsm', {});
+                }catch(ex){
+                    // Firefox 44+ (See https://bugzilla.mozilla.org/show_bug.cgi?id=912121)
+                    var { ScratchpadManager } = Cu.import('resource://devtools/client/scratchpad/scratchpad-manager.jsm', {});
+                }
                 let win = ScratchpadManager.openScratchpad();
 
                 win.addEventListener('load', () => {

--- a/chaika/chrome/content/chaika/settings/bbsmenu-pane.js
+++ b/chaika/chrome/content/chaika/settings/bbsmenu-pane.js
@@ -84,8 +84,12 @@ var gBbsmenuPane = {
         favBoardFile.appendRelativePath('favorite_boards.xml');
 
         if(ChaikaCore.pref.getBool('bbsmenu.open_favs_in_scratchpad')){
-            let { ScratchpadManager } =
-                Components.utils.import('resource:///modules/devtools/scratchpad-manager.jsm', {});
+            try{
+                var { ScratchpadManager } = Cu.import('resource:///modules/devtools/scratchpad-manager.jsm', {});
+            }catch(ex){
+                // Firefox 44+ (See https://bugzilla.mozilla.org/show_bug.cgi?id=912121)
+                var { ScratchpadManager } = Cu.import('resource://devtools/client/scratchpad/scratchpad-manager.jsm', {});
+            }
             let win = ScratchpadManager.openScratchpad();
 
             win.addEventListener('load', () => {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=912121 により、Firefox 44 から devtools のモジュール位置が変更されているため対応しました。現行 URL の import に失敗したら新しい URｌ から import します。なお URL は aurora ソースを取得して調べました。