### PR TITLE
自由にline-heightを設定するためAA部分のspan要素をinline-blockにする

### DIFF
--- a/chaika/modules/server/thread.js
+++ b/chaika/modules/server/thread.js
@@ -1643,7 +1643,7 @@ ThreadConverter.prototype = {
 
         //AAレス
         if(this.isAA(aMessage)){
-            aMessage = '<span class="aaRes">' + aMessage + '</span>';
+            aMessage = '<span class="aaRes" style="display:inline-block">' + aMessage + '</span>';
         }
 
 


### PR DESCRIPTION
報告: http://anago.2ch.net/test/read.cgi/software/1434991857/304
Default以外のスキンでも反映されるようにspanタグにインラインで指定。Default、gray、PhantomPain3、smorgas lego-ex-R で不都合が出ないことを確認しました。