### PR TITLE
コピーライトマーク以外の数値文字参照もデコードする

### DIFF
--- a/chaika/modules/ChaikaCore.js
+++ b/chaika/modules/ChaikaCore.js
@@ -1174,7 +1174,9 @@ ChaikaIO.prototype = {
                    .replace(/&quot;/g, '"')
                    .replace(/&#039;/g, "'")
                    .replace(/&amp;/g, '&')
-                   .replace(/&copy;|&#169;/g, this.fromUTF8Octets('©'));
+                   .replace(/&copy;/g, this.fromUTF8Octets('©'))
+                   .replace(/&#(x([0-9a-f]{1,6})|\d{1,7});/ig,
+                        (m, d, x) => String.fromCodePoint(!x ? parseInt(d, 10) : parseInt(x, 16)));
     },
 
 


### PR DESCRIPTION
報告: http://jbbs.shitaraba.net/bbs/read.cgi/computer/44179/1435322223/611
スレッドタイトルに絵文字が使われることがあるようなので、コピーライトマーク以外の数値文字参照もきちんとデコードするようにしました。サロゲートペアも使われてるとの話なのですが、私自身でその例を確認しておらず、そもそも数値文字参照2つでサロゲートペアなど聞いたことがないのでそれは考慮していません。