### PR TITLE
デフォルトスキンの画像ポップアップに関する改善

### DIFF
--- a/chaika/chrome/content/chaika/defaults/skin/Header.html
+++ b/chaika/chrome/content/chaika/defaults/skin/Header.html
@@ -82,6 +82,13 @@
             <label title="リンク末尾だけでなく, リンク中に画像拡張子のような文字列がある場合も画像と判定するようになります.">
                 <input type="checkbox" id="pref-enable-non-strict-image-detection"> 画像リンクの判定を緩くする
             </label>
+            <label><input type="checkbox" id="pref-image-popup-fit-to-window" /> 画像拡大時にウィンドウサイズを超えないようにする</label>
+            <fieldset class="inline-form">
+                <legend>縮小画像サイズ (上限):</legend>
+                <label>横 <input type="number" min="0" id="pref-image-popup-width" /></label> ×
+                <label>縦 <input type="number" min="0" id="pref-image-popup-height" /></label> (0で無制限)
+                </label>
+            </fieldset>
 
             <fieldset class="inline-form">
                 <legend>次の種類のポップアップを上方向に表示する:</legend>

--- a/chaika/chrome/content/chaika/defaults/skin/Header.html
+++ b/chaika/chrome/content/chaika/defaults/skin/Header.html
@@ -87,7 +87,6 @@
                 <legend>èkè¨âÊëúÉTÉCÉY (è„å¿):</legend>
                 <label>â° <input type="number" min="0" id="pref-image-popup-width" /></label> Å~
                 <label>èc <input type="number" min="0" id="pref-image-popup-height" /></label> (0Ç≈ñ≥êßå¿)
-                </label>
             </fieldset>
 
             <fieldset class="inline-form">

--- a/chaika/chrome/content/chaika/defaults/skin/script.js
+++ b/chaika/chrome/content/chaika/defaults/skin/script.js
@@ -1376,12 +1376,14 @@ var Popup = {
 
         //右端
         if(left + popupRect.width > scrollX + innerWidth){
-            left = scrollX + innerWidth - popupRect.width;
+            // ポップアップが表示領域よりも大きいときは左端を優先して揃える
+            left = scrollX + Math.max(0, innerWidth - popupRect.width);
         }
 
         //下端
         if(top + popupRect.height > scrollY + innerHeight){
-            top = scrollY + innerHeight - popupRect.height;
+            // ポップアップが表示領域よりも大きいときは上端を優先して揃える
+            top = scrollY + Math.max(0, innerHeight - popupRect.height);
         }
 
         //上端

--- a/chaika/chrome/content/chaika/defaults/skin/script.js
+++ b/chaika/chrome/content/chaika/defaults/skin/script.js
@@ -1837,10 +1837,8 @@ Popup.Image = {
         }, false);
 
         image.addEventListener('load', function(){
-            if(Prefs.get('pref-invert-image-popup-dir')){
-                let popupNode = this.closest('.popup');
-                Popup._adjustPopupPosition(link, popupNode, popupNode.dataset.inverted);
-            }
+            let popupNode = this.closest('.popup');
+            Popup._adjustPopupPosition(link, popupNode, popupNode.dataset.inverted === 'true');
         }, false);
 
         var popupContent = $.node({ 'div': { children: image }});

--- a/chaika/chrome/content/chaika/defaults/skin/script.js
+++ b/chaika/chrome/content/chaika/defaults/skin/script.js
@@ -1365,10 +1365,21 @@ var Popup = {
         let baseRect = $.rect(baseNode);
         let popupRect = $.rect(popupNode);
 
+        // スクロールバーの有無によって clientWidth/Height の値は異なる。
+        // ポップアップの表示位置がスクロールバーの表示状態に影響するし、
+        // 計算前と移動後でスクロールバーの表示状態が異なってもいけないので、
+        // 対象のポップアップを左上に移動させてから位置計算する。
+
         let scrollX = window.scrollX;
         let scrollY = window.scrollY;
-        let innerWidth = window.innerWidth;
-        let innerHeight = window.innerHeight;
+
+        $.css(popupNode, {
+            left: scrollX + 'px',
+            top: scrollY + 'px'
+        });
+
+        let innerWidth = document.documentElement.clientWidth;
+        let innerHeight = document.documentElement.clientHeight;
 
         let top = scrollY + baseRect.bottom - 2;
         let bottom = innerHeight - scrollY - baseRect.top - 2;

--- a/chaika/chrome/content/chaika/defaults/skin/script.js
+++ b/chaika/chrome/content/chaika/defaults/skin/script.js
@@ -383,6 +383,9 @@ var Prefs = {
         'pref-disable-single-id-popup': false,
         'pref-delay-popup': false,
         'pref-enable-non-strict-image-detection': false,
+        'pref-image-popup-fit-to-window': true,
+        'pref-image-popup-width': 200,
+        'pref-image-popup-height': 0,
         'pref-invert-res-popup-dir': false,
         'pref-invert-image-popup-dir': false,
         'pref-invert-id-popup-dir': false,
@@ -1798,12 +1801,39 @@ Popup.Image = {
 
         var image = $.node({ img: { 'class': 'small', 'src': linkURL }});
 
+        var popupWidth = Prefs.get('pref-image-popup-width');
+        var popupHeight = Prefs.get('pref-image-popup-height');
+        var fitToWindow = Prefs.get('pref-image-popup-fit-to-window');
+
+        $.css(image, {
+            maxWidth: popupWidth > 0 ? popupWidth + 'px' : 'none',
+            maxHeight: popupHeight > 0 ? popupHeight + 'px' : 'none'
+        });
+
         image.addEventListener('error', function(){
             this.parentNode.classList.add('error');
         }, false);
 
         image.addEventListener('click', function(){
-            this.classList.toggle('small');
+            let popupNode = this.closest('.popup');
+            if(this.classList.toggle('small')){
+                $.css(this, {
+                    maxWidth: popupWidth > 0 ? popupWidth + 'px' : 'none',
+                    maxHeight: popupHeight > 0 ? popupHeight + 'px' : 'none'
+                });
+            }else if(fitToWindow){
+                let popupRect = $.rect(popupNode);
+                let imageRect = $.rect(this);
+                $.css(this, {
+                    maxWidth: (document.documentElement.clientWidth
+                               - popupRect.width + imageRect.width) + 'px',
+                    maxHeight: (document.documentElement.clientHeight
+                                - popupRect.height + imageRect.height) + 'px'
+                });
+            }else{
+                $.css(this, { maxWidth: 'none', maxHeight: 'none' });
+            }
+            Popup._adjustPopupPosition(link, popupNode, popupNode.dataset.inverted === 'true');
         }, false);
 
         image.addEventListener('load', function(){

--- a/chaika/chrome/content/chaika/defaults/skin/style.css
+++ b/chaika/chrome/content/chaika/defaults/skin/style.css
@@ -444,8 +444,8 @@ nav > ul:hover > li > ul{
     max-width: none;
 }
 
-.small {
-    width: 200px;
+.ImagePopup img{
+    vertical-align: bottom;
 }
 
 .error > img {


### PR DESCRIPTION
2ch.netのchaikaスレに、デフォルトスキンの画像ポップアップに関する改善提案が来ていたので、
このパッチを元に、さらに自分でいろいろ改善してみたものです。
http://potato.2ch.net/test/read.cgi/software/1434991857/668

主な改善点は、
- 画像ポップアップの初期サイズをオプションから設定できるようにした
- 画像ポップアップをクリック拡大したとき、ウィンドウサイズを超えないようにするオプションを追加
- 画像ポップアップをクリックしたときポップアップの位置を補正するようにした
- ポップアップの位置補正動作に関する改善（スクロールバーを避けるなど）

ひととおりテスト済みです。画像ポップアップの使い勝手は相当改善されていると思います。
