### PR TITLE
chaika 1.8.1 での細部の様々な不具合を修正

### DIFF
--- a/chaika/chrome/content/chaika/bbsmenu/search.js
+++ b/chaika/chrome/content/chaika/bbsmenu/search.js
@@ -142,9 +142,11 @@
          * @param {String} aID 検索エンジンのID
          */
         setSearchEngine: function(aID){
-            this._engine = aID;
-
             let engineNode = this._engineMenu.querySelector('menuitem[value="' + aID + '"]');
+
+            if(!engineNode) return;
+
+            this._engine = aID;
 
             engineNode.setAttribute('checked', 'true');
             this._engineMenu.selectedItem = engineNode;

--- a/chaika/chrome/content/chaika/browser/browserMenu.xml
+++ b/chaika/chrome/content/chaika/browser/browserMenu.xml
@@ -238,16 +238,19 @@
                     return new Promise((resolve, reject) => {
                         // 応答タイムアウト設定
                         let timeoutID = setTimeout(() => {
+                            mm.removeMessageListener('chaika-get-selected-text', listener);
                             clearTimeout(timeoutID);
                             reject(new Error('chaika-get-selected-text is timeout.'));
                         }, 1000);
-                        
+
                         // frameスクリプトからの応答メッセージのlistener
-                        mm.addMessageListener('chaika-get-selected-text', message => {
+                        let listener = message => {
+                            mm.removeMessageListener('chaika-get-selected-text', listener);
                             clearTimeout(timeoutID);
                             resolve(message.data);
-                        });
-                        
+                        };
+                        mm.addMessageListener('chaika-get-selected-text', listener);
+
                         // frameスクリプトへ要求メッセージ送信
                         mm.sendAsyncMessage('chaika-get-selected-text');
                     });

--- a/chaika/modules/ChaikaHttpController.js
+++ b/chaika/modules/ChaikaHttpController.js
@@ -256,12 +256,12 @@ ChaikaImageViewURLReplace.prototype = {
         config.userAgent = data[5];
 
         if(data[3]){
-            if(data[3].contains('$COOKIE')){
+            if(data[3].includes('$COOKIE')){
                 config.cookie.shouldGet = true;
                 config.cookie.referrer = data[3].split('=')[1] || '';
             }
 
-            if(data[3].contains('$EXTRACT') && data[4]){
+            if(data[3].includes('$EXTRACT') && data[4]){
                 config.extract.pattern = data[4];
                 config.extract.referrer = data[3].split('=')[1] || '';
                 config.cookie.shouldGet = true;

--- a/chaika/modules/ChaikaSearch.js
+++ b/chaika/modules/ChaikaSearch.js
@@ -52,7 +52,7 @@ this.ChaikaSearch = {
                 let plugin = this._loadPluginFromURL(url);
 
                 // Migration: remove the old files.
-                if(plugin && plugin.updateURL && plugin.updateURL.contains('%%ChaikaDefaultsDir%%')){
+                if(plugin && plugin.updateURL && plugin.updateURL.includes('%%ChaikaDefaultsDir%%')){
                     file.remove(false);
                     continue;
                 }

--- a/chaika/modules/utils/FileIO.js
+++ b/chaika/modules/utils/FileIO.js
@@ -71,7 +71,7 @@ this.FileIO = {
                .then((text) => {
                    // If the text contains U+FFFD (REPLACEMENT CHARACTER),
                    // that means the specified encoding was wrong.
-                   if(text.contains('\uFFFD')){
+                   if(text.includes('\uFFFD')){
                        throw new Error('Wrong Encoding');
                    }
 

--- a/chaika/modules/utils/URLUtils.js
+++ b/chaika/modules/utils/URLUtils.js
@@ -87,6 +87,7 @@ let excludes = {
         /^https?:\/\/api\.2ch\.net\//,          // 2ch API entry point
         /^https?:\/\/be\.2ch\.net\//,           // 2ch Be 2.0
         /^https?:\/\/stats\.2ch\.net\//,        // 2ch Hot Threads
+        /^https?:\/\/stat\.2ch\.net\//,         // 2ch Hot Threads
         /^https?:\/\/c\.2ch\.net\//,            // Mobile-version 2ch.net
         /^https?:\/\/itest\.2ch\.net\//,        // Smartphone-version 2ch.net
         /^https?:\/\/i\.2ch\.net\//,            // Smartphone-version 2ch.net


### PR DESCRIPTION
どれも些細な修正なので、1つのプルリクにまとめました
- 廃止予定のメソッド String#contains が残っていた箇所があったので String#includes に置き換えました
- スレッドページからの選択文字列の取得で、使用済みのメッセージリスナーを登録解除するようにしました
- 存在しない検索エンジンがデフォルトになっていると、サイドバーに何も表示されなくなる現象を修正しました
- 2ch.net の発言数集計ページ stat.2ch.net/SPARROW/ が板と誤認識されていたのを修正しました
